### PR TITLE
Move 'test' to a dev dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,4 +9,6 @@ environment:
 
 dependencies:
   fixnum: ">=0.9.0 <0.11.0"
+  
+dev_dependencies:
   test: ^0.12.0


### PR DESCRIPTION
Because `test` is marked as a runtime dependency, anyone using a more recent of the package can't run `pub get`.

Typically it should be a dev dependency, so I've modified the pubspec.